### PR TITLE
Refactor `pebr-benchmark`

### DIFF
--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -24,7 +24,7 @@ sanitize = [] # Makes it more likely to trigger any potential data races.
 
 [dependencies]
 cfg-if = "0.1.2"
-memoffset = "0.2"
+memoffset = "0.7"
 
 [dependencies.arrayvec]
 version = "0.4"

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -14,7 +14,7 @@ use guard::Guard;
 /// Given ordering for the success case in a compare-exchange operation, returns the strongest
 /// appropriate ordering for the failure case.
 #[inline]
-fn strongest_failure_ordering(ord: Ordering) -> Ordering {
+pub fn strongest_failure_ordering(ord: Ordering) -> Ordering {
     use self::Ordering::*;
     match ord {
         Relaxed | Release => Relaxed,

--- a/crossbeam-epoch/src/deferred.rs
+++ b/crossbeam-epoch/src/deferred.rs
@@ -1,8 +1,8 @@
 use alloc::boxed::Box;
 use core::fmt;
 use core::marker::PhantomData;
-use core::mem;
 use core::ptr;
+use core::mem::{self, MaybeUninit};
 
 /// Number of words a piece of `Data` can hold.
 ///
@@ -18,7 +18,7 @@ type Data = [usize; DATA_WORDS];
 /// This is a handy way of keeping an unsized `FnOnce()` within a sized structure.
 pub struct Deferred {
     call: unsafe fn(*mut u8),
-    data: Data,
+    data: MaybeUninit<Data>,
     _marker: PhantomData<*mut ()>, // !Send + !Sync
 }
 
@@ -36,8 +36,8 @@ impl Deferred {
 
         unsafe {
             if size <= mem::size_of::<Data>() && align <= mem::align_of::<Data>() {
-                let mut data: Data = mem::uninitialized();
-                ptr::write(&mut data as *mut Data as *mut F, f);
+                let mut data = MaybeUninit::<Data>::uninit();
+                ptr::write(data.as_mut_ptr() as *mut F, f);
 
                 unsafe fn call<F: FnOnce()>(raw: *mut u8) {
                     let f: F = ptr::read(raw as *mut F);
@@ -51,8 +51,8 @@ impl Deferred {
                 }
             } else {
                 let b: Box<F> = Box::new(f);
-                let mut data: Data = mem::uninitialized();
-                ptr::write(&mut data as *mut Data as *mut Box<F>, b);
+                let mut data = MaybeUninit::<Data>::uninit();
+                ptr::write(data.as_mut_ptr() as *mut Box<F>, b);
 
                 unsafe fn call<F: FnOnce()>(raw: *mut u8) {
                     let b: Box<F> = ptr::read(raw as *mut Box<F>);
@@ -72,7 +72,7 @@ impl Deferred {
     #[inline]
     pub fn call(mut self) {
         let call = self.call;
-        unsafe { call(&mut self.data as *mut Data as *mut u8) };
+        unsafe { call(self.data.as_mut_ptr() as *mut u8) };
     }
 }
 

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -93,7 +93,7 @@ impl Bag {
 
     /// Seals the bag with the given epoch.
     fn seal(self, epoch: Epoch) -> SealedBag {
-        SealedBag { epoch, bag: self }
+        SealedBag { epoch, _bag: self }
     }
 }
 
@@ -108,10 +108,11 @@ impl Drop for Bag {
 
 /// A pair of an epoch and a bag.
 #[derive(Default, Debug)]
-#[allow(dead_code)]
 struct SealedBag {
     epoch: Epoch,
-    bag: Bag,
+    /// `bag` of `SealedBag` is never read.
+    /// It exists to drop inner `Bag` when its `SealedBag` becomes unreachable.
+    _bag: Bag,
 }
 
 /// It is safe to share `SealedBag` because `is_expired` only inspects the epoch.

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -108,6 +108,7 @@ impl Drop for Bag {
 
 /// A pair of an epoch and a bag.
 #[derive(Default, Debug)]
+#[allow(dead_code)]
 struct SealedBag {
     epoch: Epoch,
     bag: Bag,

--- a/crossbeam-epoch/src/sync/list.rs
+++ b/crossbeam-epoch/src/sync/list.rs
@@ -66,7 +66,7 @@ pub struct Entry {
 ///
 pub trait IsElement<T> {
     /// Returns a reference to this element's `Entry`.
-    fn entry_of(&T) -> &Entry;
+    fn entry_of(_: &T) -> &Entry;
 
     /// Given a reference to an element's entry, returns that element.
     ///
@@ -80,7 +80,7 @@ pub trait IsElement<T> {
     ///
     /// The caller has to guarantee that the `Entry` is called with was retrieved from an instance
     /// of the element type (`T`).
-    unsafe fn element_of(&Entry) -> &T;
+    unsafe fn element_of(_: &Entry) -> &T;
 
     /// The function that is called when an entry is unlinked from list.
     ///
@@ -88,7 +88,7 @@ pub trait IsElement<T> {
     ///
     /// The caller has to guarantee that the `Entry` is called with was retrieved from an instance
     /// of the element type (`T`).
-    unsafe fn finalize(&Entry, &Guard);
+    unsafe fn finalize(_: &Entry, _: &Guard);
 }
 
 /// A lock-free, intrusive linked list of type `T`.

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -139,25 +139,25 @@ impl<T> Queue<T> {
         let head = self.head.load(Acquire, guard);
         let h = unsafe { head.deref() };
         let next = h.next.load(Acquire, guard);
-        unsafe {
-            match next.as_ref() {
-                Some(n) if condition(&*n.data.as_ptr()) => {
-                    self.head
-                        .compare_and_set(head, next, Release, guard)
-                        .map(|_| {
-                            let tail = self.tail.load(Relaxed, guard);
-                            // Advance the tail so that we don't retire a pointer to a reachable node.
-                            if head == tail {
-                                let _ = self.tail.compare_and_set(tail, next, Release, guard);
-                            }
+        match unsafe { next.as_ref() } {
+            Some(n) if unsafe { condition(&*n.data.as_ptr()) } => {
+                self.head
+                    .compare_and_set(head, next, Release, guard)
+                    .map(|_| {
+                        let tail = self.tail.load(Relaxed, guard);
+                        // Advance the tail so that we don't retire a pointer to a reachable node.
+                        if head == tail {
+                            let _ = self.tail.compare_and_set(tail, next, Release, guard);
+                        }
+                        unsafe {
                             guard.defer_destroy(head);
                             // TODO: Replace with MaybeUninit::read when api is stable
                             Some(n.data.as_ptr().read())
-                        })
-                        .map_err(|_| ())
-                }
-                None | Some(_) => Ok(None),
+                        }
+                    })
+                    .map_err(|_| ())
             }
+            None | Some(_) => Ok(None),
         }
     }
 

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -5,8 +5,7 @@
 //! Michael and Scott.  Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue
 //! Algorithms.  PODC 1996.  http://dl.acm.org/citation.cfm?id=248106
 
-use core::mem::{self, ManuallyDrop};
-use core::ptr;
+use core::mem::MaybeUninit;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use crossbeam_utils::CachePadded;
@@ -26,11 +25,11 @@ pub struct Queue<T> {
 struct Node<T> {
     /// The slot in which a value of type `T` can be stored.
     ///
-    /// The type of `data` is `ManuallyDrop<T>` because a `Node<T>` doesn't always contain a `T`.
+    /// The type of `data` is `MaybeUninit<T>` because a `Node<T>` doesn't always contain a `T`.
     /// For example, the sentinel node in a queue never contains a value: its slot is always empty.
     /// Other nodes start their life with a push operation and contain a value until it gets popped
     /// out. After that such empty nodes get added to the collector for destruction.
-    data: ManuallyDrop<T>,
+    data: MaybeUninit<T>,
 
     next: Atomic<Node<T>>,
 }
@@ -47,7 +46,7 @@ impl<T> Queue<T> {
             tail: CachePadded::new(Atomic::null()),
         };
         let sentinel = Owned::new(Node {
-            data: unsafe { mem::uninitialized() },
+            data: MaybeUninit::uninit(),
             next: Atomic::null(),
         });
         unsafe {
@@ -87,7 +86,7 @@ impl<T> Queue<T> {
     /// Adds `t` to the back of the queue, possibly waking up threads blocked on `pop`.
     pub fn push(&self, t: T, guard: &Guard) {
         let new = Owned::new(Node {
-            data: ManuallyDrop::new(t),
+            data: MaybeUninit::new(t),
             next: Atomic::null(),
         });
         let new = Owned::into_shared(new, guard);
@@ -114,8 +113,14 @@ impl<T> Queue<T> {
                 self.head
                     .compare_and_set(head, next, Release, guard)
                     .map(|_| {
+                        let tail = self.tail.load(Relaxed, guard);
+                        // Advance the tail so that we don't retire a pointer to a reachable node.
+                        if head == tail {
+                            let _ = self.tail.compare_and_set(tail, next, Release, guard);
+                        }
                         guard.defer_destroy(head);
-                        Some(ManuallyDrop::into_inner(ptr::read(&n.data)))
+                        // TODO: Replace with MaybeUninit::read when api is stable
+                        Some(n.data.as_ptr().read())
                     })
                     .map_err(|_| ())
             },
@@ -134,17 +139,25 @@ impl<T> Queue<T> {
         let head = self.head.load(Acquire, guard);
         let h = unsafe { head.deref() };
         let next = h.next.load(Acquire, guard);
-        match unsafe { next.as_ref() } {
-            Some(n) if condition(&n.data) => unsafe {
-                self.head
-                    .compare_and_set(head, next, Release, guard)
-                    .map(|_| {
-                        guard.defer_destroy(head);
-                        Some(ManuallyDrop::into_inner(ptr::read(&n.data)))
-                    })
-                    .map_err(|_| ())
-            },
-            None | Some(_) => Ok(None),
+        unsafe {
+            match next.as_ref() {
+                Some(n) if condition(&*n.data.as_ptr()) => {
+                    self.head
+                        .compare_and_set(head, next, Release, guard)
+                        .map(|_| {
+                            let tail = self.tail.load(Relaxed, guard);
+                            // Advance the tail so that we don't retire a pointer to a reachable node.
+                            if head == tail {
+                                let _ = self.tail.compare_and_set(tail, next, Release, guard);
+                            }
+                            guard.defer_destroy(head);
+                            // TODO: Replace with MaybeUninit::read when api is stable
+                            Some(n.data.as_ptr().read())
+                        })
+                        .map_err(|_| ())
+                }
+                None | Some(_) => Ok(None),
+            }
         }
     }
 

--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -1,6 +1,6 @@
 use core::cell::Cell;
 use core::fmt;
-use core::sync::atomic;
+use core::hint::spin_loop;
 
 const SPIN_LIMIT: u32 = 6;
 const YIELD_LIMIT: u32 = 10;
@@ -145,7 +145,7 @@ impl Backoff {
     #[inline]
     pub fn spin(&self) {
         for _ in 0..1 << self.step.get().min(SPIN_LIMIT) {
-            atomic::spin_loop_hint();
+            spin_loop();
         }
 
         if self.step.get() <= SPIN_LIMIT {
@@ -205,12 +205,12 @@ impl Backoff {
     pub fn snooze(&self) {
         if self.step.get() <= SPIN_LIMIT {
             for _ in 0..1 << self.step.get() {
-                atomic::spin_loop_hint();
+                spin_loop();
             }
         } else {
             #[cfg(not(feature = "std"))]
             for _ in 0..1 << self.step.get() {
-                atomic::spin_loop_hint();
+                spin_loop();
             }
 
             #[cfg(feature = "std")]

--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -423,8 +423,8 @@ impl<'scope, 'env> ScopedThreadBuilder<'scope, 'env> {
                 let closure = move || closure.take().unwrap()();
 
                 // Allocate `clsoure` on the heap and erase the `'env` bound.
-                let closure: Box<FnMut() + Send + 'env> = Box::new(closure);
-                let closure: Box<FnMut() + Send + 'static> = unsafe { mem::transmute(closure) };
+                let closure: Box<dyn FnMut() + Send + 'env> = Box::new(closure);
+                let closure: Box<dyn FnMut() + Send + 'static> = unsafe { mem::transmute(closure) };
 
                 // Finally, spawn the closure.
                 let mut closure = closure;


### PR DESCRIPTION
* Remove all deprecated APIs
  * `mem::uninitialized`
    * Upgraded `memoffset = "0.7"`
    * Update `deferred.rs` and `queue.rs` with the following commits
      * https://github.com/crossbeam-rs/crossbeam/commit/e0fd465b9b7de8b60b0b588e264aca1fa92fbd18
      * https://github.com/crossbeam-rs/crossbeam/commit/b911157579a4259ca20a38e1b1b17514752b139e
      * https://github.com/crossbeam-rs/crossbeam/commit/f48c1c763a73467e2fde6158c0abc2faa162ae81
      * https://github.com/crossbeam-rs/crossbeam/commit/26188305e3ae86b8ad06b6cd58034ac1e8945686
  * `core::sync::atomic::spin_loop_hint` -> `core::hint::spin_loop`
  * Gave names(`_`) to anonymous parameters
  * Add `dyn`
  * `compare_and_swap` -> `compare_exchange`